### PR TITLE
feat(www): add geist as default font family

### DIFF
--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -1,6 +1,18 @@
-import type { Metadata } from "next";
 import "./globals.css";
+import type { Metadata } from "next";
+import { Geist, Geist_Mono as GeistMono } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-switcher";
+
+const geist = Geist({
+  subsets: ["latin"],
+  variable: "--font-geist-sans",
+  display: "swap",
+});
+const geistMono = GeistMono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
+  display: "swap",
+});
 
 const title = "Loci";
 const description =
@@ -39,8 +51,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html suppressHydrationWarning lang="en">
-      <body className="antialiased font-sans">
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${geist.variable} ${geistMono.variable}`}
+    >
+      <body className="font-sans antialiased">
         <ThemeProvider
           attribute={["class", "data-theme"]}
           defaultTheme="system"


### PR DESCRIPTION
Geist offers excellent support for both Sans and Mono fonts, making it a solid choice moving forward.

<img width="1706" height="978" alt="image" src="https://github.com/user-attachments/assets/bc27b81d-0cb2-4eeb-bd9b-174a45cd1380" />

<img width="1709" height="981" alt="image" src="https://github.com/user-attachments/assets/17ebb926-2e80-48c4-83ce-0385cdfa2f81" />
