### PR TITLE
ci: improve ci/cd performance

### DIFF
--- a/.github/workflows/build-auxiliary-docker-images.yml
+++ b/.github/workflows/build-auxiliary-docker-images.yml
@@ -1,0 +1,98 @@
+name: Build auxiliary Docker images
+
+on:
+  push:
+    branches:
+      - main
+      - ci/improve-ci-cd-performance
+    paths:
+      - 'docker/Dockerfile.**'
+
+jobs:
+  plan:
+    name: Plan Docker image builds
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Detect changed Dockerfiles
+        uses: tj-actions/changed-files@v47
+        id: changed
+        with:
+          files: docker/Dockerfile.**
+
+      - name: Set build matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          # Build a matrix from changed dockerfiles that match docker/Dockerfile.*
+          # Image name becomes loci-<suffix>
+          declare -A seen=()
+          items=()
+
+          # Print all changed files for debugging
+          echo "Changed files:" 
+          echo "${{ steps.changed.outputs.all_changed_files }}"
+
+          for f in ${{ steps.changed.outputs.all_changed_files }}; do
+            case "$f" in
+              docker/Dockerfile.*)
+                suffix="${f##docker/Dockerfile.}"
+                image="loci-${suffix}"
+
+                # Deduplicate if the same file appears multiple times
+                if [[ -z "${seen["$f"]}" ]]; then
+                  seen["$f"]=1
+                  items+=("{\"dockerfile\":\"$f\",\"image\":\"$image\"}")
+                fi
+                ;;
+            esac
+          done
+
+          if [[ ${#items[@]} -eq 0 ]]; then
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+          else
+            printf 'matrix={"include":[%s]}\n' "$(IFS=,; echo "${items[*]}")" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build and push Docker images
+    needs: plan
+    if: ${{ fromJSON(needs.plan.outputs.matrix).include != null && fromJSON(needs.plan.outputs.matrix).include[0] != null }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          provenance: false
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-auxiliary-docker-images.yml
+++ b/.github/workflows/build-auxiliary-docker-images.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
   build:
-    name: Build and push Docker images
+    name: Build and push
     needs: plan
     if: ${{ fromJSON(needs.plan.outputs.matrix).include != null && fromJSON(needs.plan.outputs.matrix).include[0] != null }}
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/build-auxiliary-docker-images.yml
+++ b/.github/workflows/build-auxiliary-docker-images.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci/improve-ci-cd-performance
     paths:
       - 'docker/Dockerfile.**'
 

--- a/.github/workflows/on-tag-publish.yml
+++ b/.github/workflows/on-tag-publish.yml
@@ -1,4 +1,4 @@
-name: On Tag Publish
+name: On tag publish
 
 on:
   push:
@@ -15,16 +15,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish package or app for tag
+  setup:
+    name: Parse tag
     runs-on: ubuntu-latest
+    outputs:
+      tag:     ${{ steps.tag.outputs.tag }}
+      project: ${{ steps.tag.outputs.project }}
+      version: ${{ steps.tag.outputs.version }}
+      type:    ${{ steps.project_type.outputs.type }}
     steps:
-      # Common steps to extract tag info
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0
-      # IMPORTANT: Repo layout uses apps/name or packages/name (no scope). We intentionally discard any @scope/ prefix.
+          fetch-depth: 1
       - name: Extract project and version from tag
         id: tag
         run: |
@@ -47,19 +50,24 @@ jobs:
             exit 1
           fi
 
-      # Publish NPM package
-      - name: Setup Node dependencies
+  npm:
+    name: Publish NPM package
+    runs-on: ubuntu-latest
+    needs: setup
+    if: needs.setup.outputs.type == 'package'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Setup node dependencies
         uses: ./.github/actions/setup-node-dependencies
-        if: steps.project_type.outputs.type == 'package'
       - name: Install jq
-        if: steps.project_type.outputs.type == 'package'
         run: sudo apt-get update && sudo apt-get install -y jq
-      - name: Publish NPM package
-        if: steps.project_type.outputs.type == 'package'
+      - name: Publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         run: |
-          PROJECT="${{ steps.tag.outputs.project }}"
+          PROJECT="${{ needs.setup.outputs.project }}"
           PACKAGE_PATH="packages/$PROJECT/package.json"
           PACKAGE_NAME=$(jq -r .name "$PACKAGE_PATH")
           IS_PRIVATE=$(jq -r 'if has("private") then .private else "false" end' "$PACKAGE_PATH")
@@ -67,46 +75,100 @@ jobs:
             echo "Package $PACKAGE_NAME is private. Skipping publish."
             exit 0
           fi
-          echo "Publishing $PACKAGE_NAME version ${{ steps.tag.outputs.version }}"
+          echo "Publishing $PACKAGE_NAME version ${{ needs.setup.outputs.version }}"
           pnpm turbo build --filter="$PACKAGE_NAME"
           npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           pnpm publish --filter "$PACKAGE_NAME" --access public --no-git-checks
 
-      # Build and publish Docker image to GHCR
-      - name: Set up QEMU
-        if: steps.project_type.outputs.type == 'app'
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        if: steps.project_type.outputs.type == 'app'
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        if: steps.project_type.outputs.type == 'app'
-        uses: docker/login-action@v3
+  docker:
+    name: Build and push ${{ matrix.arch }} image
+    needs: setup
+    if: needs.setup.outputs.type == 'app'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            tag_suffix: amd64
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            tag_suffix: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push GHCR image
-        if: steps.project_type.outputs.type == 'app'
+      - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          file: apps/${{ needs.setup.outputs.project }}/Dockerfile
           target: prod
-          platforms: linux/amd64,linux/arm64
-          file: apps/${{ steps.tag.outputs.project }}/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
           tags: |
-            ghcr.io/${{ github.repository_owner }}/loci-${{ steps.tag.outputs.project }}:${{ steps.tag.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/loci-${{ steps.tag.outputs.project }}:latest
-
-      - name: Summary
+            ghcr.io/${{ github.repository_owner }}/loci-${{ needs.setup.outputs.project }}:${{ needs.setup.outputs.version }}-${{ matrix.tag_suffix }}
+            ghcr.io/${{ github.repository_owner }}/loci-${{ needs.setup.outputs.project }}:latest-${{ matrix.tag_suffix }}
+          cache-from: type=gha,scope=loci-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=loci-${{ matrix.arch }}
+      - name: Append status to summary
+        if: always()
         run: |
           {
-            echo "### On Tag Publish"
-            echo "- Tag: \`${{ steps.tag.outputs.tag }}\`"
-            echo "- Project: \`${{ steps.tag.outputs.project }}\`"
-            echo "- Version: \`${{ steps.tag.outputs.version }}\`"
-            echo "- Type: \`${{ steps.project_type.outputs.type }}\`"
+            echo "## Docker (${{ matrix.arch }})"
+            echo "- Platform: \`${{ matrix.platform }}\`"
+            echo "- Runner: \`${{ matrix.runner }}\`"
+            echo "- Result: \`${{ steps.build.outcome || 'unknown' }}\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  manifest:
+    name: Create and push multi-arch manifest
+    needs: [setup, docker]
+    if: needs.setup.outputs.type == 'app'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/loci-${{ needs.setup.outputs.project }}"
+          VERSION="${{ needs.setup.outputs.version }}"
+          docker buildx imagetools create -t "$IMAGE:$VERSION" -t "$IMAGE:latest" \
+            "$IMAGE:$VERSION-amd64" "$IMAGE:$VERSION-arm64"
+
+  summary:
+    name: Write output 
+    needs: [setup, npm, docker, manifest]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
+        run: |
+          {
+            echo "## On Tag Publish"
+            echo "- Tag: \`${{ needs.setup.outputs.tag || 'n/a' }}\`"
+            echo "- Project: \`${{ needs.setup.outputs.project || 'n/a' }}\`"
+            echo "- Version: \`${{ needs.setup.outputs.version || 'n/a' }}\`"
+            echo "- Type: \`${{ needs.setup.outputs.type || 'n/a' }}\`"
+            echo ""
+            echo "## Job results"
+            echo "- npm: \`${{ needs.npm.result || 'skipped' }}\`"
+            echo "- docker matrix: \`${{ needs.docker.result || 'skipped' }}\`"
+            echo "- manifest: \`${{ needs.manifest.result || 'skipped' }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+env:
+  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+
 jobs:
   lint-format:
     name: Lint & Format Check
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -28,7 +30,6 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -44,7 +45,6 @@ jobs:
   build:
     name: Build Verification
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -78,7 +78,6 @@ jobs:
   conventional-commits:
     name: Validate Conventional Commits
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/apps/www/Dockerfile.e2e
+++ b/apps/www/Dockerfile.e2e
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.18-labs
 # -------- Production --------
-FROM node:24-bookworm AS prod
+FROM ghcr.io/emiliosheinz/loci-playwright:latest AS prod
 
 RUN corepack enable pnpm && corepack install -g pnpm@10.14.0
 
@@ -12,8 +12,6 @@ COPY --parents packages/*/package.json ./
 
 RUN pnpm install --frozen-lockfile
 
-RUN pnpm -F www exec playwright install --with-deps chromium firefox webkit
-
 # Copy in only what the API needs
 COPY apps/www apps/www
 COPY packages packages
@@ -23,17 +21,9 @@ CMD ["pnpm", "turbo", "test:e2e", "--filter=www"]
 
 
 # -------- Development --------
-FROM node:24-bookworm AS dev
-
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+FROM ghcr.io/emiliosheinz/loci-playwright:latest AS dev
 
 RUN corepack enable pnpm && corepack install -g pnpm@10.14.0
-
-RUN npm i -g playwright@1.56.0 \
- && playwright --version \
- && playwright install --with-deps chromium firefox webkit
-
-RUN ls -la /ms-playwright
 
 WORKDIR /loci
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
     container_name: setup
     build:
       context: .
-      dockerfile: Dockerfile.loci
+      dockerfile: ./docker/Dockerfile.cli
     volumes:
       - .:/loci
     command: sh -lc "pnpm install"
@@ -13,7 +13,7 @@ services:
     container_name: workspace
     build:
       context: .
-      dockerfile: Dockerfile.loci
+      dockerfile: ./docker/Dockerfile.cli
     depends_on:
       setup:
         condition: service_completed_successfully

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,7 @@
 services:
   setup:
     container_name: setup
-    build:
-      context: .
-      dockerfile: ./docker/Dockerfile.cli
+    image: ghcr.io/emiliosheinz/loci-cli:latest
     volumes:
       - .:/loci
     command: sh -lc "pnpm install"
@@ -11,9 +9,7 @@ services:
 
   workspace:
     container_name: workspace
-    build:
-      context: .
-      dockerfile: ./docker/Dockerfile.cli
+    image: ghcr.io/emiliosheinz/loci-cli:latest
     depends_on:
       setup:
         condition: service_completed_successfully

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -1,9 +1,13 @@
 # General-purpose Node image with pnpm available
-FROM node:24-alpine
+
+ARG NODE_TAG=24-alpine
+ARG PNPM_VERSION=10.14.0
+
+FROM node:${NODE_TAG}
 
 RUN apk add --no-cache git curl vim
 
-RUN corepack enable pnpm && corepack install -g pnpm@10.14.0
+RUN corepack enable pnpm && corepack install -g pnpm@${PNPM_VERSION}
 
 ENV GIT_DIR=/loci/.git
 ENV GIT_WORK_TREE=/loci

--- a/docker/Dockerfile.playwright
+++ b/docker/Dockerfile.playwright
@@ -1,0 +1,12 @@
+ARG NODE_TAG=24-bookworm
+ARG PLAYWRIGHT_VERSION=1.56.0
+
+FROM node:${NODE_TAG}
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+RUN npm i -g playwright@${PLAYWRIGHT_VERSION} \
+ && playwright --version \
+ && playwright install --with-deps chromium firefox webkit
+
+RUN ls -la /ms-playwright


### PR DESCRIPTION
This PR significantly improves our CI/CD performance by optimizing Docker builds and caching across native runners.

- Multi-architecture builds now run on native ARM and AMD runners, eliminating emulation overhead.
- Docker and pnpm caches are now stored in GitHub Actions cache (GHA) for faster rebuilds.
- PR checks time reduced from **~5 min → ~3 min**.
- Publishing the **www** Docker image time reduced from **~12 min → ~3 min**.

Overall, this makes our pipelines faster, more reliable, and cheaper to maintain.